### PR TITLE
Add comprehensive test suite for UnionChecker

### DIFF
--- a/buildutils/union-checker/pom.xml
+++ b/buildutils/union-checker/pom.xml
@@ -44,5 +44,42 @@
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>framework-test</artifactId>
+            <version>${checkerframework.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- The tests invoke the javac compiler API directly, which requires access
+                         to javac internals not exported by the jdk.compiler module. -->
+                    <argLine>
+                        --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+                        --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+                        --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+                        --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+                        --add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+                        --add-opens jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+                        --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+                        --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+                        --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+                        --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+                        --add-opens jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/buildutils/union-checker/src/test/java/org/apache/axiom/checker/union/UnionCheckerTest.java
+++ b/buildutils/union-checker/src/test/java/org/apache/axiom/checker/union/UnionCheckerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.axiom.checker.union;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Runs the {@link UnionChecker} against the test sources in {@code tests/union}. */
+public class UnionCheckerTest extends CheckerFrameworkPerDirectoryTest {
+
+    public UnionCheckerTest(List<File> testFiles) {
+        super(testFiles, UnionChecker.class, "union", "-Anomsgtext");
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"union"};
+    }
+}

--- a/buildutils/union-checker/tests/union/ConditionalLub.java
+++ b/buildutils/union-checker/tests/union/ConditionalLub.java
@@ -1,0 +1,33 @@
+import org.apache.axiom.checker.union.Union;
+
+/**
+ * Tests for the least upper bound of two {@code @Union} qualifiers at a conditional expression
+ * ({@code UnionQualifierHierarchy#leastUpperBoundWithElements}).
+ */
+class ConditionalLub {
+
+    static class A {}
+
+    static class B {}
+
+    void acceptAOrB(@Union(types = {A.class, B.class}) Object o) {}
+
+    void acceptAOnly(@Union(types = {A.class}) Object o) {}
+
+    // The lub of @Union({A}) and @Union({B}) is @Union({A, B}).
+    void lub(
+            boolean flag,
+            @Union(types = {A.class}) Object a,
+            @Union(types = {B.class}) Object b) {
+        acceptAOrB(flag ? a : b);
+    }
+
+    // @Union({A, B}) is not a subtype of @Union({A}).
+    void lubNotNarrower(
+            boolean flag,
+            @Union(types = {A.class}) Object a,
+            @Union(types = {B.class}) Object b) {
+        // :: error: (argument)
+        acceptAOnly(flag ? a : b);
+    }
+}

--- a/buildutils/union-checker/tests/union/ConditionalLub.java
+++ b/buildutils/union-checker/tests/union/ConditionalLub.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import org.apache.axiom.checker.union.Union;
 
 /**

--- a/buildutils/union-checker/tests/union/ConditionalPromotion.java
+++ b/buildutils/union-checker/tests/union/ConditionalPromotion.java
@@ -1,0 +1,33 @@
+import org.apache.axiom.checker.union.Union;
+
+/**
+ * Tests for promoting the type of a conditional expression to {@code @Union(types = {...})} when
+ * one branch is {@code @UnknownUnion} but its erased type is a subtype of a union member
+ * ({@code UnionTreeAnnotator}).
+ */
+class ConditionalPromotion {
+
+    // sb has erased type StringBuilder, a subtype of CharSequence, so the conditional
+    // expression is promoted to @Union({String, CharSequence}), regardless of which branch it
+    // appears in.
+    @Union(types = {String.class, CharSequence.class}) Object unknownSecond(
+            boolean flag,
+            @Union(types = {String.class, CharSequence.class}) Object data, StringBuilder sb) {
+        return flag ? sb : data;
+    }
+
+    @Union(types = {String.class, CharSequence.class}) Object unknownFirst(
+            boolean flag,
+            @Union(types = {String.class, CharSequence.class}) Object data, StringBuilder sb) {
+        return flag ? data : sb;
+    }
+
+    // other has erased type Object, which is not a subtype of String or CharSequence, so no
+    // promotion happens and the conditional expression's type remains @UnknownUnion, which is not
+    // a subtype of the declared @Union return type.
+    @Union(types = {String.class, CharSequence.class}) Object noPromotion(
+            boolean flag, @Union(types = {String.class, CharSequence.class}) Object data, Object other) {
+        // :: error: (return)
+        return flag ? other : data;
+    }
+}

--- a/buildutils/union-checker/tests/union/ConditionalPromotion.java
+++ b/buildutils/union-checker/tests/union/ConditionalPromotion.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import org.apache.axiom.checker.union.Union;
 
 /**

--- a/buildutils/union-checker/tests/union/InstanceofNarrowing.java
+++ b/buildutils/union-checker/tests/union/InstanceofNarrowing.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import org.apache.axiom.checker.union.Union;
 
 /** Tests for {@code instanceof}-based narrowing ({@code UnionTransfer}). */

--- a/buildutils/union-checker/tests/union/InstanceofNarrowing.java
+++ b/buildutils/union-checker/tests/union/InstanceofNarrowing.java
@@ -1,0 +1,37 @@
+import org.apache.axiom.checker.union.Union;
+
+/** Tests for {@code instanceof}-based narrowing ({@code UnionTransfer}). */
+class InstanceofNarrowing {
+
+    void acceptStringOrInteger(@Union(types = {String.class, Integer.class}) Object o) {}
+
+    void acceptIntegerOnly(@Union(types = {Integer.class}) Object o) {}
+
+    // x instanceof String || x instanceof Integer narrows x to @Union({String, Integer}).
+    void or(Object x) {
+        if (x instanceof String || x instanceof Integer) {
+            acceptStringOrInteger(x);
+        }
+    }
+
+    // The equivalent if/else if chain narrows x the same way in each branch.
+    void elseIf(Object x) {
+        if (x instanceof String) {
+            acceptStringOrInteger(x);
+        } else if (x instanceof Integer) {
+            acceptStringOrInteger(x);
+        } else {
+            // :: error: (argument)
+            acceptStringOrInteger(x);
+        }
+    }
+
+    // x instanceof String narrows x to @Union({String}), which is not a subtype of
+    // @Union({Integer}).
+    void mismatch(Object x) {
+        if (x instanceof String) {
+            // :: error: (argument)
+            acceptIntegerOnly(x);
+        }
+    }
+}

--- a/buildutils/union-checker/tests/union/NullAssignment.java
+++ b/buildutils/union-checker/tests/union/NullAssignment.java
@@ -1,0 +1,13 @@
+import org.apache.axiom.checker.union.Union;
+
+/** Tests that {@code null} ({@code @UnionBottom}) is assignable to any {@code @Union} type. */
+class NullAssignment {
+
+    @Union(types = {String.class, Integer.class}) Object field = null;
+
+    void acceptStringOrInteger(@Union(types = {String.class, Integer.class}) Object o) {}
+
+    void test() {
+        acceptStringOrInteger(null);
+    }
+}

--- a/buildutils/union-checker/tests/union/NullAssignment.java
+++ b/buildutils/union-checker/tests/union/NullAssignment.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import org.apache.axiom.checker.union.Union;
 
 /** Tests that {@code null} ({@code @UnionBottom}) is assignable to any {@code @Union} type. */

--- a/buildutils/union-checker/tests/union/Subtyping.java
+++ b/buildutils/union-checker/tests/union/Subtyping.java
@@ -1,0 +1,25 @@
+import org.apache.axiom.checker.union.Union;
+
+/** Tests for {@code @Union} subset-based subtyping ({@code UnionQualifierHierarchy}). */
+class Subtyping {
+
+    void acceptNarrow(@Union(types = {String.class}) Object o) {}
+
+    void acceptWide(@Union(types = {String.class, Integer.class}) Object o) {}
+
+    // @Union({String}) is a subtype of @Union({String, Integer}).
+    void narrowToWide(@Union(types = {String.class}) Object narrow) {
+        acceptWide(narrow);
+    }
+
+    // @Union({String, Integer}) is not a subtype of @Union({String}).
+    void wideToNarrow(@Union(types = {String.class, Integer.class}) Object wide) {
+        // :: error: (argument)
+        acceptNarrow(wide);
+    }
+
+    // Equal sets are subtypes of each other.
+    void sameSet(@Union(types = {Integer.class, String.class}) Object wide) {
+        acceptWide(wide);
+    }
+}

--- a/buildutils/union-checker/tests/union/Subtyping.java
+++ b/buildutils/union-checker/tests/union/Subtyping.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import org.apache.axiom.checker.union.Union;
 
 /** Tests for {@code @Union} subset-based subtyping ({@code UnionQualifierHierarchy}). */

--- a/buildutils/union-checker/tests/union/UnknownUnionEscape.java
+++ b/buildutils/union-checker/tests/union/UnknownUnionEscape.java
@@ -1,0 +1,29 @@
+import org.apache.axiom.checker.union.Union;
+
+/**
+ * Tests for the {@code @UnknownUnion} escape rule, which allows an unconstrained value to be used
+ * where {@code @Union(types = {...})} is expected if its erased type is a subtype of one of the
+ * union members ({@code UnionTypeHierarchy}).
+ */
+class UnknownUnionEscape {
+
+    void acceptStringOrCharSequence(@Union(types = {String.class, CharSequence.class}) Object o) {}
+
+    void acceptIntegerOnly(@Union(types = {Integer.class}) Object o) {}
+
+    // String is itself one of the union members.
+    void exactMember(String s) {
+        acceptStringOrCharSequence(s);
+    }
+
+    // StringBuilder is a subtype of CharSequence, a union member.
+    void subtypeOfMember(StringBuilder sb) {
+        acceptStringOrCharSequence(sb);
+    }
+
+    // StringBuilder is not a subtype of Integer, the only union member.
+    void notAMember(StringBuilder sb) {
+        // :: error: (argument)
+        acceptIntegerOnly(sb);
+    }
+}

--- a/buildutils/union-checker/tests/union/UnknownUnionEscape.java
+++ b/buildutils/union-checker/tests/union/UnknownUnionEscape.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import org.apache.axiom.checker.union.Union;
 
 /**


### PR DESCRIPTION
## Summary
This PR adds a complete test suite for the UnionChecker annotation processor, including test infrastructure and five test cases covering the core functionality of the union type checking system.

## Key Changes
- **Test Infrastructure**: Added `UnionCheckerTest` class that extends `CheckerFrameworkPerDirectoryTest` to run checker tests against source files in the `tests/union` directory
- **Maven Configuration**: Updated `pom.xml` to include test dependencies (Checker Framework test utilities and JUnit) and configured maven-surefire-plugin with necessary JVM module access flags for javac internals
- **Test Cases**: Added five comprehensive test files covering:
  - **Subtyping.java**: Tests subset-based subtyping rules where `@Union({String})` is a subtype of `@Union({String, Integer})`
  - **InstanceofNarrowing.java**: Tests type narrowing through `instanceof` checks in conditional expressions
  - **ConditionalLub.java**: Tests least upper bound computation for union types in conditional expressions
  - **ConditionalPromotion.java**: Tests promotion of conditional expression types when one branch has an erased type matching a union member
  - **UnknownUnionEscape.java**: Tests the escape rule allowing unconstrained values to be used where union types are expected if their erased type matches a union member
  - **NullAssignment.java**: Tests that `null` is assignable to any union type

## Notable Implementation Details
- The test suite uses Checker Framework's standard per-directory test pattern with error markers (`// :: error: (...)`) to validate expected type checking failures
- JVM module access is configured to allow tests to invoke the javac compiler API directly, which is required for the annotation processor to function during testing
- Test cases are organized to progressively cover the union type system's core features: basic subtyping, type narrowing, type promotion, and special cases like null handling

https://claude.ai/code/session_01EMwSi6Fw4xYj5riDQqQn4n