### PR TITLE
Annotate TextContent.blobObject with @Union(Blob, BlobProvider)

### DIFF
--- a/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/intf/TextContent.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/intf/TextContent.java
@@ -56,9 +56,7 @@ public final class TextContent implements CloneableCharacterData {
     }
 
     public TextContent(
-            String contentID,
-            @Union(types = {Blob.class, BlobProvider.class}) Object blobObject,
-            boolean optimize) {
+            String contentID, @Union(types = {Blob.class, BlobProvider.class}) Object blobObject, boolean optimize) {
         this.value = null;
         this.contentID = contentID;
         this.blobObject = blobObject;

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/intf/TextContent.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/intf/TextContent.java
@@ -46,7 +46,7 @@ public final class TextContent implements CloneableCharacterData {
      * Contains a {@link Blob} or {@link BlobProvider} object if the text node represents base64
      * encoded binary data.
      */
-    private Object blobObject;
+    private @Union(types = {Blob.class, BlobProvider.class}) Object blobObject;
 
     private boolean optimize;
     private boolean binary;
@@ -55,7 +55,10 @@ public final class TextContent implements CloneableCharacterData {
         this.value = value;
     }
 
-    public TextContent(String contentID, Object blobObject, boolean optimize) {
+    public TextContent(
+            String contentID,
+            @Union(types = {Blob.class, BlobProvider.class}) Object blobObject,
+            boolean optimize) {
         this.value = null;
         this.contentID = contentID;
         this.blobObject = blobObject;
@@ -107,7 +110,7 @@ public final class TextContent implements CloneableCharacterData {
      *
      * @return a {@link Blob} or {@link BlobProvider} object for the base64 decoded content
      */
-    public Object getBlobObject() {
+    public @Union(types = {Blob.class, BlobProvider.class}) Object getBlobObject() {
         if (!binary) {
             throw new IllegalStateException();
         }

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/stream/xop/XOPEncodingFilterHandler.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/stream/xop/XOPEncodingFilterHandler.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.apache.axiom.blob.Blob;
+import org.apache.axiom.checker.union.Union;
 import org.apache.axiom.core.stream.StreamException;
 import org.apache.axiom.core.stream.XmlHandler;
 import org.apache.axiom.core.stream.xop.AbstractXOPEncodingFilterHandler;
@@ -34,7 +35,8 @@ import org.apache.axiom.om.impl.intf.TextContent;
 
 public final class XOPEncodingFilterHandler extends AbstractXOPEncodingFilterHandler
         implements XOPHandler, OMAttachmentAccessor {
-    private final Map<String, Object> blobObjects = new LinkedHashMap<String, Object>();
+    private final Map<String, @Union(types = {Blob.class, BlobProvider.class}) Object> blobObjects =
+            new LinkedHashMap<String, @Union(types = {Blob.class, BlobProvider.class}) Object>();
     private final ContentIDGenerator contentIDGenerator;
     private final OptimizationPolicy optimizationPolicy;
 


### PR DESCRIPTION
## Summary
- `TextContent.blobObject` (and the related getter/constructor parameter) holds either a `Blob` or a `BlobProvider`; annotate it with `@Union(types = {Blob.class, BlobProvider.class})` so the union checker verifies the `instanceof`-based narrowing.
- `XOPEncodingFilterHandler.blobObjects` map stores the same union of types, so its value type is annotated the same way.

## Test plan
- [x] `mvn -pl mixins/om-mixins -am compile` succeeds with the union checker enabled
- [x] `mvn -pl mixins/om-mixins -am test` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01JkH73mr481zQLYGzr1xbG3)_