### PR TITLE
Use diamond operator for generic type instantiations

### DIFF
--- a/axiom-api/src/main/java/org/apache/axiom/locator/Activator.java
+++ b/axiom-api/src/main/java/org/apache/axiom/locator/Activator.java
@@ -44,7 +44,7 @@ public class Activator implements BundleActivator {
         OMAbstractFactory.setMetaFactoryLocator(locator);
         // Bundle.STARTING covers the case where the implementation bundle has
         // "Bundle-ActivationPolicy: lazy".
-        tracker = new BundleTracker<List<RegisteredImplementation>>(context, Bundle.STARTING | Bundle.ACTIVE, locator);
+        tracker = new BundleTracker<>(context, Bundle.STARTING | Bundle.ACTIVE, locator);
         tracker.open();
         log.debug("OSGi support enabled");
     }

--- a/axiom-api/src/main/java/org/apache/axiom/locator/DefaultOMMetaFactoryLocator.java
+++ b/axiom-api/src/main/java/org/apache/axiom/locator/DefaultOMMetaFactoryLocator.java
@@ -44,7 +44,7 @@ public final class DefaultOMMetaFactoryLocator extends PriorityBasedOMMetaFactor
 
         Loader loader = new DefaultLoader(classLoader);
 
-        List<Implementation> implementations = new ArrayList<Implementation>();
+        List<Implementation> implementations = new ArrayList<>();
 
         // If a meta factory is specified using the system property, we register it as an
         // implementation with feature "default" and maximum priority, so that it will always

--- a/axiom-api/src/main/java/org/apache/axiom/locator/ImplementationFactory.java
+++ b/axiom-api/src/main/java/org/apache/axiom/locator/ImplementationFactory.java
@@ -80,7 +80,7 @@ final class ImplementationFactory {
         if (log.isDebugEnabled()) {
             log.debug("Loading " + url);
         }
-        List<Implementation> implementations = new ArrayList<Implementation>();
+        List<Implementation> implementations = new ArrayList<>();
         try {
             // Since this code is used to discover Axiom implementations, we have to use DOM here.
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -150,7 +150,7 @@ final class ImplementationFactory {
         if (metaFactory == null) {
             return null;
         }
-        List<Feature> features = new ArrayList<Feature>();
+        List<Feature> features = new ArrayList<>();
         Node child = implementation.getFirstChild();
         while (child != null) {
             if (child instanceof Element) {

--- a/axiom-api/src/main/java/org/apache/axiom/locator/OSGiOMMetaFactoryLocator.java
+++ b/axiom-api/src/main/java/org/apache/axiom/locator/OSGiOMMetaFactoryLocator.java
@@ -34,7 +34,7 @@ import org.osgi.util.tracker.BundleTrackerCustomizer;
 final class OSGiOMMetaFactoryLocator extends PriorityBasedOMMetaFactoryLocator
         implements BundleTrackerCustomizer<List<RegisteredImplementation>> {
     private final BundleContext apiBundleContext;
-    private final List<Implementation> implementations = new ArrayList<Implementation>();
+    private final List<Implementation> implementations = new ArrayList<>();
 
     OSGiOMMetaFactoryLocator(BundleContext apiBundleContext) {
         this.apiBundleContext = apiBundleContext;
@@ -53,7 +53,7 @@ final class OSGiOMMetaFactoryLocator extends PriorityBasedOMMetaFactoryLocator
             List<Implementation> discoveredImplementations =
                     ImplementationFactory.parseDescriptor(new OSGiLoader(bundle), descriptorUrl);
             List<RegisteredImplementation> registeredImplementations =
-                    new ArrayList<RegisteredImplementation>(discoveredImplementations.size());
+                    new ArrayList<>(discoveredImplementations.size());
             synchronized (this) {
                 implementations.addAll(discoveredImplementations);
                 loadImplementations(implementations);
@@ -62,12 +62,12 @@ final class OSGiOMMetaFactoryLocator extends PriorityBasedOMMetaFactoryLocator
                 List<ServiceRegistration<?>> registrations = new ArrayList<ServiceRegistration<?>>();
                 List<ServiceReference<?>> references = new ArrayList<ServiceReference<?>>();
                 for (Feature feature : implementation.getFeatures()) {
-                    List<String> clazzes = new ArrayList<String>();
+                    List<String> clazzes = new ArrayList<>();
                     clazzes.add(OMMetaFactory.class.getName());
                     for (Class<?> extensionInterface : feature.getExtensionInterfaces()) {
                         clazzes.add(extensionInterface.getName());
                     }
-                    Hashtable<String, Object> properties = new Hashtable<String, Object>();
+                    Hashtable<String, Object> properties = new Hashtable<>();
                     properties.put("implementationName", implementation.getName());
                     properties.put("feature", feature.getName());
                     properties.put(Constants.SERVICE_RANKING, feature.getPriority());

--- a/axiom-api/src/main/java/org/apache/axiom/locator/PriorityBasedOMMetaFactoryLocator.java
+++ b/axiom-api/src/main/java/org/apache/axiom/locator/PriorityBasedOMMetaFactoryLocator.java
@@ -29,10 +29,10 @@ import org.apache.commons.logging.LogFactory;
 class PriorityBasedOMMetaFactoryLocator implements OMMetaFactoryLocator {
     private static final Log log = LogFactory.getLog(PriorityBasedOMMetaFactoryLocator.class);
 
-    private final Map<String, OMMetaFactory> factories = new HashMap<String, OMMetaFactory>();
+    private final Map<String, OMMetaFactory> factories = new HashMap<>();
 
     void loadImplementations(List<Implementation> implementations) {
-        Map<String, Integer> priorityMap = new HashMap<String, Integer>();
+        Map<String, Integer> priorityMap = new HashMap<>();
         factories.clear();
         for (Implementation implementation : implementations) {
             Feature[] features = implementation.getFeatures();

--- a/axiom-api/src/main/java/org/apache/axiom/mime/ContentType.java
+++ b/axiom-api/src/main/java/org/apache/axiom/mime/ContentType.java
@@ -65,7 +65,7 @@ import java.util.Objects;
 public final class ContentType {
     public static final class Builder {
         private MediaType mediaType;
-        private final LinkedHashMap<String, String> parameters = new LinkedHashMap<String, String>();
+        private final LinkedHashMap<String, String> parameters = new LinkedHashMap<>();
 
         Builder() {}
 
@@ -185,7 +185,7 @@ public final class ContentType {
         tokenizer.require('/');
         String subType = tokenizer.requireToken();
         mediaType = new MediaType(primaryType, subType);
-        List<String> parameters = new ArrayList<String>();
+        List<String> parameters = new ArrayList<>();
         while (tokenizer.expect(';')) {
             String name = tokenizer.expectToken();
             if (name == null) {

--- a/axiom-api/src/main/java/org/apache/axiom/mime/MultipartBody.java
+++ b/axiom-api/src/main/java/org/apache/axiom/mime/MultipartBody.java
@@ -124,7 +124,7 @@ public final class MultipartBody implements Iterable<Part> {
     private final MimeTokenStream parser;
 
     /** Stores the already parsed MIME parts by Content IDs. */
-    private final Map<String, PartImpl> partMap = new HashMap<String, PartImpl>();
+    private final Map<String, PartImpl> partMap = new HashMap<>();
 
     /** The MIME part currently being processed. */
     private PartImpl currentPart;
@@ -249,7 +249,7 @@ public final class MultipartBody implements Iterable<Part> {
             try {
                 checkParserState(parser.next(), EntityState.T_START_HEADER);
 
-                List<Header> headers = new ArrayList<Header>();
+                List<Header> headers = new ArrayList<>();
                 while (parser.next() == EntityState.T_FIELD) {
                     Field field = parser.getField();
                     String name = field.getName();

--- a/axiom-api/src/main/java/org/apache/axiom/om/OMOutputFormat.java
+++ b/axiom-api/src/main/java/org/apache/axiom/om/OMOutputFormat.java
@@ -123,7 +123,7 @@ public class OMOutputFormat {
         contentTypeProvider = format.contentTypeProvider;
         contentTransferEncodingPolicy = format.contentTransferEncodingPolicy;
         if (format.map != null) {
-            map = new HashMap<String, Object>(format.map);
+            map = new HashMap<>(format.map);
         }
     }
 
@@ -145,7 +145,7 @@ public class OMOutputFormat {
      */
     public Object setProperty(String key, Object value) {
         if (map == null) {
-            map = new HashMap<String, Object>();
+            map = new HashMap<>();
         }
         return map.put(key, value);
     }

--- a/axiom-api/src/main/java/org/apache/axiom/om/ds/AbstractOMDataSource.java
+++ b/axiom-api/src/main/java/org/apache/axiom/om/ds/AbstractOMDataSource.java
@@ -57,7 +57,7 @@ public abstract class AbstractOMDataSource implements OMDataSourceExt {
     @Override
     public final Object setProperty(String key, Object value) {
         if (properties == null) {
-            properties = new HashMap<String, Object>();
+            properties = new HashMap<>();
         }
         return properties.put(key, value);
     }

--- a/axiom-api/src/main/java/org/apache/axiom/om/util/DigestGenerator.java
+++ b/axiom-api/src/main/java/org/apache/axiom/om/util/DigestGenerator.java
@@ -260,7 +260,7 @@ public class DigestGenerator {
      * @return Returns the collection of attributes which are none namespace declarations
      */
     public Collection<OMAttribute> getAttributesWithoutNS(OMElement element) {
-        SortedMap<String, OMAttribute> map = new TreeMap<String, OMAttribute>();
+        SortedMap<String, OMAttribute> map = new TreeMap<>();
         Iterator<OMAttribute> itr = element.getAllAttributes();
         while (itr.hasNext()) {
             OMAttribute attribute = itr.next();
@@ -278,7 +278,7 @@ public class DigestGenerator {
      * @return Returns a collection of OMProcessingInstructions and OMElements
      */
     public Collection<OMNode> getValidElements(OMDocument document) {
-        ArrayList<OMNode> list = new ArrayList<OMNode>();
+        ArrayList<OMNode> list = new ArrayList<>();
         Iterator<OMNode> itr = document.getChildren();
         while (itr.hasNext()) {
             OMNode node = itr.next();

--- a/axiom-api/src/main/java/org/apache/axiom/om/util/StAXUtils.java
+++ b/axiom-api/src/main/java/org/apache/axiom/om/util/StAXUtils.java
@@ -86,11 +86,11 @@ public class StAXUtils {
     private static final Log log = LogFactory.getLog(StAXUtils.class);
 
     private static final Map<StAXParserConfiguration, XMLInputFactory> inputFactoryMap =
-            Collections.synchronizedMap(new WeakHashMap<StAXParserConfiguration, XMLInputFactory>());
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     @SuppressWarnings("deprecation")
     private static final Map<StAXWriterConfiguration, XMLOutputFactory> outputFactoryMap =
-            Collections.synchronizedMap(new WeakHashMap<StAXWriterConfiguration, XMLOutputFactory>());
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     /**
      * Get a cached {@link XMLInputFactory} instance using the default configuration.
@@ -322,7 +322,7 @@ public class StAXUtils {
         } else {
             try {
                 Properties rawProps = new Properties();
-                Map<String, Object> props = new HashMap<String, Object>();
+                Map<String, Object> props = new HashMap<>();
                 rawProps.load(in);
                 for (Map.Entry<Object, Object> entry : rawProps.entrySet()) {
                     String strValue = (String) entry.getValue();

--- a/axiom-api/src/main/java/org/apache/axiom/om/xpath/AXIOMXPath.java
+++ b/axiom-api/src/main/java/org/apache/axiom/om/xpath/AXIOMXPath.java
@@ -32,7 +32,7 @@ public class AXIOMXPath extends BaseXPath {
 
     private static final long serialVersionUID = -5839161412925154639L;
 
-    private Map<String, String> namespaces = new HashMap<String, String>();
+    private Map<String, String> namespaces = new HashMap<>();
 
     /**
      * Construct an XPath expression from a given string.

--- a/axiom-api/src/main/java/org/apache/axiom/om/xpath/DocumentNavigator.java
+++ b/axiom-api/src/main/java/org/apache/axiom/om/xpath/DocumentNavigator.java
@@ -366,13 +366,13 @@ public class DocumentNavigator extends DefaultNavigator {
         if (!(contextNode instanceof OMElement omContextNode)) {
             return JaxenConstants.EMPTY_ITERATOR;
         }
-        List<OMNamespaceEx> nsList = new ArrayList<OMNamespaceEx>();
-        Set<String> prefixes = new HashSet<String>();
+        List<OMNamespaceEx> nsList = new ArrayList<>();
+        Set<String> prefixes = new HashSet<>();
         for (OMContainer context = omContextNode;
                 context != null && !(context instanceof OMDocument);
                 context = ((OMElement) context).getParent()) {
             OMElement element = (OMElement) context;
-            List<OMNamespace> declaredNS = new ArrayList<OMNamespace>();
+            List<OMNamespace> declaredNS = new ArrayList<>();
             Iterator<OMNamespace> i = element.getAllDeclaredNamespaces();
             while (i != null && i.hasNext()) {
                 declaredNS.add(i.next());
@@ -487,7 +487,7 @@ public class DocumentNavigator extends DefaultNavigator {
      */
     @Override
     public Iterator<?> getFollowingSiblingAxisIterator(Object contextNode) throws UnsupportedAxisException {
-        List<OMNode> list = new ArrayList<OMNode>();
+        List<OMNode> list = new ArrayList<>();
         if (contextNode != null && contextNode instanceof OMNode node) {
             while (true) {
                 node = node.getNextOMSibling();
@@ -511,7 +511,7 @@ public class DocumentNavigator extends DefaultNavigator {
      */
     @Override
     public Iterator<?> getPrecedingSiblingAxisIterator(Object contextNode) throws UnsupportedAxisException {
-        List<OMNode> list = new ArrayList<OMNode>();
+        List<OMNode> list = new ArrayList<>();
         if (contextNode != null && contextNode instanceof OMNode node) {
             while (true) {
                 node = node.getPreviousOMSibling();

--- a/axiom-api/src/main/java/org/apache/axiom/util/stax/debug/XMLStreamReaderValidator.java
+++ b/axiom-api/src/main/java/org/apache/axiom/util/stax/debug/XMLStreamReaderValidator.java
@@ -40,7 +40,7 @@ public class XMLStreamReaderValidator extends XMLStreamReaderWrapper {
     private static boolean IS_ADV_DEBUG_ENABLED = false; // Turn this on to trace every event
 
     private boolean throwExceptions = false; // Indicates whether OMException should be thrown if errors are disovered
-    private Stack<QName> stack = new Stack<QName>(); // Stack keeps track of the nested element QName
+    private Stack<QName> stack = new Stack<>(); // Stack keeps track of the nested element QName
 
     /**
      * @param delegate XMLStreamReader to validate

--- a/axiom-api/src/main/java/org/apache/axiom/util/stax/dialect/SJSXPNamespaceContextWrapper.java
+++ b/axiom-api/src/main/java/org/apache/axiom/util/stax/dialect/SJSXPNamespaceContextWrapper.java
@@ -46,7 +46,7 @@ class SJSXPNamespaceContextWrapper implements NamespaceContext {
     @Override
     public Iterator<String> getPrefixes(String namespaceURI) {
         // SJSXP doesn't correctly handle masked namespace declarations
-        List<String> prefixes = new ArrayList<String>(5);
+        List<String> prefixes = new ArrayList<>(5);
         for (Iterator<?> it = parent.getPrefixes(namespaceURI); it.hasNext(); ) {
             String prefix = (String) it.next();
             String actualNamespaceURI = parent.getNamespaceURI(prefix);

--- a/axiom-api/src/main/java/org/apache/axiom/util/stax/dialect/StAXDialectDetector.java
+++ b/axiom-api/src/main/java/org/apache/axiom/util/stax/dialect/StAXDialectDetector.java
@@ -66,8 +66,7 @@ public class StAXDialectDetector {
      * the case of a JAR file, this is not the URL pointing to the JAR, but a {@code jar:} URL that
      * points to the root folder of the archive.
      */
-    private static final Map<URL, StAXDialect> dialectByUrl =
-            Collections.synchronizedMap(new HashMap<>());
+    private static final Map<URL, StAXDialect> dialectByUrl = Collections.synchronizedMap(new HashMap<>());
 
     private StAXDialectDetector() {}
 

--- a/axiom-api/src/main/java/org/apache/axiom/util/stax/dialect/StAXDialectDetector.java
+++ b/axiom-api/src/main/java/org/apache/axiom/util/stax/dialect/StAXDialectDetector.java
@@ -67,7 +67,7 @@ public class StAXDialectDetector {
      * points to the root folder of the archive.
      */
     private static final Map<URL, StAXDialect> dialectByUrl =
-            Collections.synchronizedMap(new HashMap<URL, StAXDialect>());
+            Collections.synchronizedMap(new HashMap<>());
 
     private StAXDialectDetector() {}
 

--- a/axiom-api/src/test/java/org/apache/axiom/om/MethodCollisionTestCase.java
+++ b/axiom-api/src/test/java/org/apache/axiom/om/MethodCollisionTestCase.java
@@ -41,7 +41,7 @@ public class MethodCollisionTestCase extends TestCase {
     }
 
     private Set<MethodSignature> getMethodSignatures(Class<?> iface) {
-        Set<MethodSignature> result = new HashSet<MethodSignature>();
+        Set<MethodSignature> result = new HashSet<>();
         Method[] methods = iface.getMethods();
         for (int i = 0; i < methods.length; i++) {
             result.add(new MethodSignature(methods[i]));

--- a/axiom-api/src/test/java/org/apache/axiom/util/UIDGeneratorTest.java
+++ b/axiom-api/src/test/java/org/apache/axiom/util/UIDGeneratorTest.java
@@ -35,7 +35,7 @@ public class UIDGeneratorTest extends TestCase {
 
     public void testGenerateContentIdUniqueness() {
         // Not very sophisticated, but should catch stupid regressions
-        Set<String> values = new HashSet<String>();
+        Set<String> values = new HashSet<>();
         for (int i = 0; i < 1000; i++) {
             assertTrue(values.add(UIDGenerator.generateContentId()));
         }
@@ -46,7 +46,7 @@ public class UIDGeneratorTest extends TestCase {
     }
 
     public void testGenerateUIDThreadSafety() {
-        Set<String> generatedIds = Collections.synchronizedSet(new HashSet<String>());
+        Set<String> generatedIds = Collections.synchronizedSet(new HashSet<>());
         AtomicInteger errorCount = new AtomicInteger(0);
         Thread[] threads = new Thread[100];
         for (int i = 0; i < threads.length; i++) {
@@ -94,7 +94,7 @@ public class UIDGeneratorTest extends TestCase {
             }
         }
 
-        Set<String> set = new HashSet<String>();
+        Set<String> set = new HashSet<>();
         for (int i = 0; i < threads.length; i++) {
             for (int j = 0; j < urns[i].length; j++) {
                 String urn = urns[i][j];

--- a/axiom-compat/src/main/java/org/apache/axiom/mime/ContentTypeBuilder.java
+++ b/axiom-compat/src/main/java/org/apache/axiom/mime/ContentTypeBuilder.java
@@ -30,7 +30,7 @@ import java.util.Locale;
  */
 public final class ContentTypeBuilder {
     private MediaType mediaType;
-    private final LinkedHashMap<String, String> parameters = new LinkedHashMap<String, String>();
+    private final LinkedHashMap<String, String> parameters = new LinkedHashMap<>();
 
     /**
      * Constructor that initializes the builder with a media type and no parameters.

--- a/axiom-compat/src/main/java/org/apache/axiom/om/ds/OMDataSourceExtBase.java
+++ b/axiom-compat/src/main/java/org/apache/axiom/om/ds/OMDataSourceExtBase.java
@@ -68,7 +68,7 @@ public abstract class OMDataSourceExtBase implements OMDataSourceExt {
     @Override
     public Object setProperty(String key, Object value) {
         if (map == null) {
-            map = new HashMap<String, Object>();
+            map = new HashMap<>();
         }
         return map.put(key, value);
     }

--- a/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/AttachmentCacheMonitor.java
+++ b/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/AttachmentCacheMonitor.java
@@ -50,7 +50,7 @@ public final class AttachmentCacheMonitor {
     // HashMap
     // Key String = Absolute file name
     // Value Long = Last Access Time
-    private Map<String, Long> files = new HashMap<String, Long>();
+    private Map<String, Long> files = new HashMap<>();
 
     // Delete detection is batched
     private Long priorDeleteMillis = getTime();

--- a/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/AttachmentSet.java
+++ b/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/AttachmentSet.java
@@ -34,7 +34,7 @@ import org.apache.axiom.om.OMException;
  * attachment parts.
  */
 class AttachmentSet extends AttachmentsDelegate {
-    private final Map<String, DataHandler> attachmentsMap = new LinkedHashMap<String, DataHandler>();
+    private final Map<String, DataHandler> attachmentsMap = new LinkedHashMap<>();
 
     @Override
     ContentType getContentType() {

--- a/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/Attachments.java
+++ b/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/Attachments.java
@@ -391,7 +391,7 @@ public class Attachments implements OMAttachmentAccessor {
      * @return List of content IDs in order of appearance in message
      */
     public List<String> getContentIDList() {
-        return new ArrayList<String>(delegate.getContentIDs(false));
+        return new ArrayList<>(delegate.getContentIDs(false));
     }
 
     /**

--- a/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/IncomingAttachmentInputStream.java
+++ b/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/IncomingAttachmentInputStream.java
@@ -62,8 +62,8 @@ public class IncomingAttachmentInputStream extends InputStream {
      */
     public void addHeader(String name, String value) {
         if (_headers == null) {
-            _headers = new HashMap<String, String>();
-            _headersLowerCase = new HashMap<String, String>();
+            _headers = new HashMap<>();
+            _headersLowerCase = new HashMap<>();
         }
         _headers.put(name, value);
         _headersLowerCase.put(name.toLowerCase(), value);

--- a/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/MultipartBodyAdapter.java
+++ b/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/MultipartBodyAdapter.java
@@ -44,7 +44,7 @@ final class MultipartBodyAdapter extends AttachmentsDelegate implements PartCrea
     private static final Log log = LogFactory.getLog(MultipartBodyAdapter.class);
 
     private final MultipartBody message;
-    private final Map<String, DataHandler> map = new LinkedHashMap<String, DataHandler>();
+    private final Map<String, DataHandler> map = new LinkedHashMap<>();
     private final int contentLength;
     private final CountingInputStream filterIS;
     private final Part rootPart;

--- a/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/lifecycle/impl/LifecycleManagerImpl.java
+++ b/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/lifecycle/impl/LifecycleManagerImpl.java
@@ -31,7 +31,7 @@ public class LifecycleManagerImpl implements LifecycleManager {
     private static final Log log = LogFactory.getLog(LifecycleManagerImpl.class);
 
     // Hashtable to store file accessors.
-    private static Hashtable<String, FileAccessor> table = new Hashtable<String, FileAccessor>();
+    private static Hashtable<String, FileAccessor> table = new Hashtable<>();
     private VMShutdownHook hook = null;
 
     public LifecycleManagerImpl() {

--- a/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/lifecycle/impl/VMShutdownHook.java
+++ b/axiom-legacy-attachments/src/main/java/org/apache/axiom/attachments/lifecycle/impl/VMShutdownHook.java
@@ -35,7 +35,7 @@ import org.apache.commons.logging.LogFactory;
 public class VMShutdownHook extends Thread {
     private static final Log log = LogFactory.getLog(VMShutdownHook.class);
     private static VMShutdownHook instance = null;
-    private static Set<File> files = Collections.synchronizedSet(new HashSet<File>());
+    private static Set<File> files = Collections.synchronizedSet(new HashSet<>());
     private boolean isRegistered = false;
 
     static VMShutdownHook hook() {

--- a/axiom-legacy-attachments/src/test/java/org/apache/axiom/attachments/MyLifecycleManager.java
+++ b/axiom-legacy-attachments/src/test/java/org/apache/axiom/attachments/MyLifecycleManager.java
@@ -26,7 +26,7 @@ import org.apache.axiom.attachments.lifecycle.impl.FileAccessor;
 import org.apache.axiom.attachments.lifecycle.impl.LifecycleManagerImpl;
 
 public class MyLifecycleManager extends LifecycleManagerImpl {
-    private final Set<File> files = new HashSet<File>();
+    private final Set<File> files = new HashSet<>();
 
     @Override
     public FileAccessor create(String attachmentDir) throws IOException {

--- a/axiom-weaver/src/main/java/org/apache/axiom/weaver/WeavingClassLoader.java
+++ b/axiom-weaver/src/main/java/org/apache/axiom/weaver/WeavingClassLoader.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.apache.axiom.weaver.mixin.ClassDefinition;
 
 final class WeavingClassLoader extends ClassLoader {
-    private final Map<String, ClassDefinition> classDefinitions = new HashMap<String, ClassDefinition>();
+    private final Map<String, ClassDefinition> classDefinitions = new HashMap<>();
 
     WeavingClassLoader(ClassLoader parent, ClassDefinition[] classDefinitions) {
         super(parent);

--- a/components/core-streams/src/main/java/org/apache/axiom/core/stream/sax/input/XmlHandlerContentHandler.java
+++ b/components/core-streams/src/main/java/org/apache/axiom/core/stream/sax/input/XmlHandlerContentHandler.java
@@ -154,7 +154,7 @@ public final class XmlHandlerContentHandler implements ContentHandler, LexicalHa
     @Override
     public void internalEntityDecl(String name, String value) throws SAXException {
         if (entities == null) {
-            entities = new HashMap<String, String>();
+            entities = new HashMap<>();
         }
         entities.put(name, value);
         if (!inExternalSubset) {

--- a/components/core-streams/src/main/java/org/apache/axiom/core/stream/sax/output/ContentHandlerXmlHandler.java
+++ b/components/core-streams/src/main/java/org/apache/axiom/core/stream/sax/output/ContentHandlerXmlHandler.java
@@ -47,7 +47,7 @@ public class ContentHandlerXmlHandler implements XmlHandler, CharacterDataSink {
     private int bindings;
     private int[] scopeStack = new int[8];
     private int depth;
-    private Stack<String> elementNameStack = new Stack<String>();
+    private Stack<String> elementNameStack = new Stack<>();
     private String elementURI;
     private String elementLocalName;
     private String elementQName;

--- a/components/core-streams/src/main/java/org/apache/axiom/core/stream/stax/pull/output/StAXPivot.java
+++ b/components/core-streams/src/main/java/org/apache/axiom/core/stream/stax/pull/output/StAXPivot.java
@@ -481,7 +481,7 @@ public final class StAXPivot implements InternalXMLStreamReader, XmlHandler {
             Object extension = extensionFactory.createExtension(name, this);
             if (extension != null) {
                 if (extensions == null) {
-                    extensions = new HashMap<String, Object>();
+                    extensions = new HashMap<>();
                 }
                 extensions.put(name, extension);
                 return extension;

--- a/components/core-streams/src/main/java/org/apache/axiom/core/stream/stax/push/input/XmlHandlerStreamWriter.java
+++ b/components/core-streams/src/main/java/org/apache/axiom/core/stream/stax/push/input/XmlHandlerStreamWriter.java
@@ -103,7 +103,7 @@ public final class XmlHandlerStreamWriter implements InternalXMLStreamWriter, Na
             Object extension = extensionFactory.createExtension(name, this);
             if (extension != null) {
                 if (extensions == null) {
-                    extensions = new HashMap<String, Object>();
+                    extensions = new HashMap<>();
                 }
                 extensions.put(name, extension);
                 return extension;

--- a/components/namespace-utils/src/main/java/org/apache/axiom/util/namespace/MapBasedNamespaceContext.java
+++ b/components/namespace-utils/src/main/java/org/apache/axiom/util/namespace/MapBasedNamespaceContext.java
@@ -66,7 +66,7 @@ public class MapBasedNamespaceContext extends AbstractNamespaceContext {
             String uri = entry.getValue();
             if (uri.equals(nsURI)) {
                 if (prefixes == null) {
-                    prefixes = new HashSet<String>();
+                    prefixes = new HashSet<>();
                 }
                 prefixes.add(entry.getKey());
             }

--- a/components/namespace-utils/src/test/java/org/apache/axiom/util/namespace/ScopedNamespaceContextTest.java
+++ b/components/namespace-utils/src/test/java/org/apache/axiom/util/namespace/ScopedNamespaceContextTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 
 public class ScopedNamespaceContextTest {
     private static Set<String> getPrefixes(NamespaceContext nc, String namespaceURI) {
-        Set<String> result = new HashSet<String>();
+        Set<String> result = new HashSet<>();
         for (Iterator<?> it = nc.getPrefixes(namespaceURI); it.hasNext(); ) {
             result.add((String) it.next());
         }
@@ -65,7 +65,7 @@ public class ScopedNamespaceContextTest {
         nc.setPrefix("b", "urn:ns1");
         String prefix = nc.getPrefix("urn:ns1");
         assertThat(prefix).isIn("", "b");
-        assertThat(getPrefixes(nc, "urn:ns1")).isEqualTo(new HashSet<String>(Arrays.asList("", "b")));
+        assertThat(getPrefixes(nc, "urn:ns1")).isEqualTo(new HashSet<>(Arrays.asList("", "b")));
     }
 
     @Test

--- a/components/xml-utils/src/main/java/org/apache/axiom/util/xml/QNameMap.java
+++ b/components/xml-utils/src/main/java/org/apache/axiom/util/xml/QNameMap.java
@@ -58,7 +58,7 @@ public final class QNameMap<V> {
             entry = entry.next;
         }
         if (entry == null) {
-            entry = new QNameMapEntry<V>();
+            entry = new QNameMapEntry<>();
             entry.qname = qname;
             entry.next = buckets[index];
             buckets[index] = entry;

--- a/components/xml-utils/src/test/java/org/apache/axiom/util/xml/NSUtilsTest.java
+++ b/components/xml-utils/src/test/java/org/apache/axiom/util/xml/NSUtilsTest.java
@@ -36,7 +36,7 @@ public class NSUtilsTest {
      */
     @Test
     public void testUniqueness() throws Exception {
-        Set<String> prefixes = new HashSet<String>();
+        Set<String> prefixes = new HashSet<>();
         BufferedReader in = new BufferedReader(
                 new InputStreamReader(NSUtilsTest.class.getResourceAsStream("namespaces.txt"), StandardCharsets.UTF_8));
         try {

--- a/components/xml-utils/src/test/java/org/apache/axiom/util/xml/QNameMapTest.java
+++ b/components/xml-utils/src/test/java/org/apache/axiom/util/xml/QNameMapTest.java
@@ -34,8 +34,7 @@ public class QNameMapTest {
 
     @Test
     public void testGetWithNullLocalPart() {
-        assertThatThrownBy(() -> new QNameMap<>().get("urn:test", null))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new QNameMap<>().get("urn:test", null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/components/xml-utils/src/test/java/org/apache/axiom/util/xml/QNameMapTest.java
+++ b/components/xml-utils/src/test/java/org/apache/axiom/util/xml/QNameMapTest.java
@@ -27,20 +27,20 @@ import org.junit.jupiter.api.Test;
 public class QNameMapTest {
     @Test
     public void testGetWithNullNamespaceURI() {
-        QNameMap<String> map = new QNameMap<String>();
+        QNameMap<String> map = new QNameMap<>();
         map.put(new QName(null, "name"), "value");
         assertThat(map.get(null, "name")).isEqualTo("value");
     }
 
     @Test
     public void testGetWithNullLocalPart() {
-        assertThatThrownBy(() -> new QNameMap<Object>().get("urn:test", null))
+        assertThatThrownBy(() -> new QNameMap<>().get("urn:test", null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void testReplaceExisting() {
-        QNameMap<String> map = new QNameMap<String>();
+        QNameMap<String> map = new QNameMap<>();
         map.put(new QName("urn:test", "name"), "value1");
         map.put(new QName("urn:test", "name"), "value2");
         assertThat(map.get("urn:test", "name")).isEqualTo("value2");
@@ -48,7 +48,7 @@ public class QNameMapTest {
 
     @Test
     public void testHashCollision() {
-        QNameMap<String> map = new QNameMap<String>();
+        QNameMap<String> map = new QNameMap<>();
         map.put(new QName("a", "b"), "value1");
         map.put(new QName("b", "a"), "value2");
         assertThat(map.get("a", "b")).isEqualTo("value1");

--- a/mixins/core-mixins/src/main/java/org/apache/axiom/core/Mappers.java
+++ b/mixins/core-mixins/src/main/java/org/apache/axiom/core/Mappers.java
@@ -27,7 +27,7 @@ public final class Mappers {
     @SuppressWarnings("unchecked")
     public static <S, T extends S> Mapper<S, T> upcast() {
         // This is an optimization for the following type safe instruction:
-        // return new IdentityMapper<S,T>();
+        // return new IdentityMapper<>();
         return IDENTITY;
     }
 

--- a/mixins/core-mixins/src/main/java/org/apache/axiom/core/impl/AttributeIterator.java
+++ b/mixins/core-mixins/src/main/java/org/apache/axiom/core/impl/AttributeIterator.java
@@ -52,7 +52,7 @@ public final class AttributeIterator<T extends CoreAttribute, S> implements Iter
         if (attribute == null) {
             return Collections.<S>emptyList().iterator();
         } else {
-            return new AttributeIterator<T, S>(attribute, type, mapper, semantics);
+            return new AttributeIterator<>(attribute, type, mapper, semantics);
         }
     }
 

--- a/mixins/core-mixins/src/main/java/org/apache/axiom/core/impl/builder/BuilderHandler.java
+++ b/mixins/core-mixins/src/main/java/org/apache/axiom/core/impl/builder/BuilderHandler.java
@@ -66,7 +66,7 @@ final class BuilderHandler implements XmlHandler {
 
     void addListener(BuilderListener listener) {
         if (listeners == null) {
-            listeners = new ArrayList<BuilderListener>();
+            listeners = new ArrayList<>();
         }
         listeners.add(listener);
     }

--- a/mixins/core-mixins/src/main/java/org/apache/axiom/core/impl/mixin/CoreParentNodeMixin.java
+++ b/mixins/core-mixins/src/main/java/org/apache/axiom/core/impl/mixin/CoreParentNodeMixin.java
@@ -428,7 +428,7 @@ public abstract class CoreParentNodeMixin implements CoreParentNode {
     @Override
     public final <T extends CoreNode, S> NodeIterator<S> coreGetNodes(
             Axis axis, Class<T> type, Mapper<S, ? super T> mapper, Semantics semantics) {
-        return new NodesIterator<T, S>(this, axis, type, mapper, semantics);
+        return new NodesIterator<>(this, axis, type, mapper, semantics);
     }
 
     @Override
@@ -440,7 +440,7 @@ public abstract class CoreParentNodeMixin implements CoreParentNode {
             String name,
             Mapper<S, ? super T> mapper,
             Semantics semantics) {
-        return new ElementsIterator<T, S>(this, axis, type, matcher, namespaceURI, name, mapper, semantics);
+        return new ElementsIterator<>(this, axis, type, matcher, namespaceURI, name, mapper, semantics);
     }
 
     @Override

--- a/mixins/dom-mixins/src/main/java/org/apache/axiom/dom/DOMConfigurationImpl.java
+++ b/mixins/dom-mixins/src/main/java/org/apache/axiom/dom/DOMConfigurationImpl.java
@@ -79,7 +79,7 @@ public final class DOMConfigurationImpl implements DOMConfiguration {
             | VALIDATE
             | VALIDATE_IF_SCHEMA;
 
-    private static final Map<String, Integer> paramMap = new HashMap<String, Integer>();
+    private static final Map<String, Integer> paramMap = new HashMap<>();
 
     static {
         paramMap.put(CANONICAL_FORM_PARAM, Integer.valueOf(CANONICAL_FORM));

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/common/LiveNamespaceContext.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/common/LiveNamespaceContext.java
@@ -47,7 +47,7 @@ public final class LiveNamespaceContext extends AbstractNamespaceContext {
 
     @Override
     protected Iterator<String> doGetPrefixes(String namespaceURI) {
-        List<String> prefixes = new ArrayList<String>();
+        List<String> prefixes = new ArrayList<>();
         for (Iterator<OMNamespace> it = element.getNamespacesInScope(); it.hasNext(); ) {
             OMNamespace ns = it.next();
             if (ns.getNamespaceURI().equals(namespaceURI)) {

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/common/NamespaceIterator.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/common/NamespaceIterator.java
@@ -28,7 +28,7 @@ import org.apache.axiom.om.OMNamespace;
 
 /** Iterator implementation used by {@link OMElement#getNamespacesInScope()}. */
 public final class NamespaceIterator implements Iterator<OMNamespace> {
-    private final Set<String> seenPrefixes = new HashSet<String>();
+    private final Set<String> seenPrefixes = new HashSet<>();
     private OMElement element;
     private Iterator<OMNamespace> declaredNamespaces;
     private boolean hasNextCalled;

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/common/builder/CustomBuilderManager.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/common/builder/CustomBuilderManager.java
@@ -48,7 +48,7 @@ final class CustomBuilderManager implements BuilderListener {
 
     void register(CustomBuilder.Selector selector, CustomBuilder customBuilder) {
         if (registrations == null) {
-            registrations = new ArrayList<CustomBuilderRegistration>();
+            registrations = new ArrayList<>();
         }
         registrations.add(new CustomBuilderRegistration(selector, customBuilder));
         // Try to apply the new custom builder to the element currently being built (unless it has

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/mixin/AxiomContainerMixin.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/mixin/AxiomContainerMixin.java
@@ -154,7 +154,7 @@ public abstract class AxiomContainerMixin implements AxiomContainer {
         } catch (StreamException ex) {
             throw new OMException(ex);
         }
-        return new XOPEncoded<XMLStreamReader>(pivot, encoder);
+        return new XOPEncoded<>(pivot, encoder);
     }
 
     @Override

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/mixin/AxiomElementMixin.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/mixin/AxiomElementMixin.java
@@ -135,7 +135,7 @@ public abstract class AxiomElementMixin implements AxiomElement {
     @Override
     public NamespaceContext getNamespaceContext(boolean detached) {
         if (detached) {
-            Map<String, String> namespaces = new HashMap<String, String>();
+            Map<String, String> namespaces = new HashMap<>();
             for (Iterator<OMNamespace> it = getNamespacesInScope(); it.hasNext(); ) {
                 OMNamespace ns = it.next();
                 namespaces.put(ns.getPrefix(), ns.getNamespaceURI());

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/stream/NamespaceContextPreservationFilterHandler.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/stream/NamespaceContextPreservationFilterHandler.java
@@ -46,7 +46,7 @@ public final class NamespaceContextPreservationFilterHandler extends XmlHandlerW
     public void startElement(String namespaceURI, String localName, String prefix) throws StreamException {
         super.startElement(namespaceURI, localName, prefix);
         if (!done) {
-            prefixesAlreadyBound = new HashSet<String>();
+            prefixesAlreadyBound = new HashSet<>();
         }
     }
 

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/common/builder/SOAP12BuilderHelper.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/common/builder/SOAP12BuilderHelper.java
@@ -165,7 +165,7 @@ public class SOAP12BuilderHelper extends SOAPBuilderHelper {
             } else if (parent.getLocalName().equals(SOAP12Constants.SOAP_FAULT_DETAIL_LOCAL_NAME)) {
                 elementType = AxiomNodeFactory::createNSAwareElement;
                 processingDetailElements = true;
-                detailElementNames = new Vector<String>();
+                detailElementNames = new Vector<>();
                 detailElementNames.add(localName);
 
             } else {

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/mixin/AxiomSOAP12FaultReasonMixin.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/mixin/AxiomSOAP12FaultReasonMixin.java
@@ -48,7 +48,7 @@ public abstract class AxiomSOAP12FaultReasonMixin implements AxiomSOAP12FaultRea
 
     @Override
     public final List<SOAPFaultText> getAllSoapTexts() {
-        List<SOAPFaultText> faultTexts = new ArrayList<SOAPFaultText>();
+        List<SOAPFaultText> faultTexts = new ArrayList<>();
         for (Iterator<OMElement> it = getChildElements(); it.hasNext(); ) {
             faultTexts.add((SOAPFaultText) it.next());
         }

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/mixin/AxiomSOAPHeaderMixin.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/mixin/AxiomSOAPHeaderMixin.java
@@ -157,7 +157,7 @@ public abstract class AxiomSOAPHeaderMixin implements AxiomSOAPHeader {
 
     @Override
     public final ArrayList<SOAPHeaderBlock> getHeaderBlocksWithNSURI(String nsURI) {
-        ArrayList<SOAPHeaderBlock> result = new ArrayList<SOAPHeaderBlock>();
+        ArrayList<SOAPHeaderBlock> result = new ArrayList<>();
         for (Iterator<SOAPHeaderBlock> it = getHeaderBlocksWithNamespaceURI(nsURI); it.hasNext(); ) {
             result.add(it.next());
         }
@@ -165,7 +165,7 @@ public abstract class AxiomSOAPHeaderMixin implements AxiomSOAPHeader {
     }
 
     private Iterator<SOAPHeaderBlock> extract(Iterator<SOAPHeaderBlock> it) {
-        List<SOAPHeaderBlock> result = new ArrayList<SOAPHeaderBlock>();
+        List<SOAPHeaderBlock> result = new ArrayList<>();
         while (it.hasNext()) {
             SOAPHeaderBlock headerBlock = it.next();
             it.remove();

--- a/systests/osgi-tests/src/test/java/org/apache/axiom/test/UsesConstraintsTest.java
+++ b/systests/osgi-tests/src/test/java/org/apache/axiom/test/UsesConstraintsTest.java
@@ -91,7 +91,7 @@ public class UsesConstraintsTest {
     @Test
     public void test() throws Exception {
         System.setProperty("java.protocol.handler.pkgs", "org.ops4j.pax.url");
-        Map<String, String> p = new HashMap<String, String>();
+        Map<String, String> p = new HashMap<>();
         p.put(FRAMEWORK_STORAGE, new File("target/felix").getAbsolutePath());
         p.put(FRAMEWORK_STORAGE_CLEAN, FRAMEWORK_STORAGE_CLEAN_ONFIRSTINIT);
         FrameworkFactory frameworkFactory = new org.apache.felix.framework.FrameworkFactory();
@@ -100,7 +100,7 @@ public class UsesConstraintsTest {
         BundleContext context = framework.getBundleContext();
         Listener listener = new Listener();
         context.addFrameworkListener(listener);
-        List<Bundle> bundles = new ArrayList<Bundle>();
+        List<Bundle> bundles = new ArrayList<>();
         bundles.add(context.installBundle("link:classpath:META-INF/links/org.ops4j.pax.logging.api.link"));
         bundles.add(context.installBundle("link:classpath:org.apache.aries.spifly.dynamic.framework.extension.link"));
         bundles.add(context.installBundle("link:classpath:org.apache.servicemix.specs.stax-api-1.0.link"));

--- a/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/OMTestSuite.java
+++ b/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/OMTestSuite.java
@@ -1016,7 +1016,7 @@ public class OMTestSuite {
                 new MatrixTest(org.apache.axiom.ts.om.text.TestGetNamespace.class),
                 new MatrixTest(org.apache.axiom.ts.om.text.TestGetNamespaceNoNamespace.class),
                 new MatrixTest(org.apache.axiom.ts.om.text.TestGetTextCharactersFromDataHandler.class),
-                new FanOutNode<Integer>(
+                new FanOutNode<>(
                         ImmutableList.of(
                                 (int) OMNode.TEXT_NODE, (int) OMNode.SPACE_NODE, (int) OMNode.CDATA_SECTION_NODE),
                         Binding.singleton(Key.get(Integer.class, Names.named("type"))),

--- a/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/builder/TestCloseWithXMLStreamReader.java
+++ b/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/builder/TestCloseWithXMLStreamReader.java
@@ -41,7 +41,7 @@ public class TestCloseWithXMLStreamReader implements Executable {
         try {
             XMLStreamReader reader = StAXUtils.createXMLStreamReader(in);
             OMXMLParserWrapper builder = OMXMLBuilderFactory.createStAXOMBuilder(factory, reader);
-            WeakReference<XMLStreamReader> readerWeakRef = new WeakReference<XMLStreamReader>(reader);
+            WeakReference<XMLStreamReader> readerWeakRef = new WeakReference<>(reader);
             reader = null;
             builder.getDocument().build();
             builder.close();

--- a/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/element/TestGetAllDeclaredNamespacesRemove.java
+++ b/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/element/TestGetAllDeclaredNamespacesRemove.java
@@ -47,7 +47,7 @@ public class TestGetAllDeclaredNamespacesRemove implements Executable {
             for (String prefix : prefixes) {
                 element.declareNamespace("urn:" + prefix, prefix);
             }
-            Set<String> seenPrefixes = new HashSet<String>();
+            Set<String> seenPrefixes = new HashSet<>();
             for (Iterator<OMNamespace> it = element.getAllDeclaredNamespaces(); it.hasNext(); ) {
                 OMNamespace ns = it.next();
                 String prefix = ns.getPrefix();

--- a/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/element/TestGetTextAsStreamWithoutCaching.java
+++ b/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/element/TestGetTextAsStreamWithoutCaching.java
@@ -46,7 +46,7 @@ public class TestGetTextAsStreamWithoutCaching implements Executable {
     public void execute() throws Throwable {
         Charset charset = StandardCharsets.US_ASCII;
         Blob blob = new RandomBlob(654321, 64, 128, 20000000);
-        Vector<InputStream> v = new Vector<InputStream>();
+        Vector<InputStream> v = new Vector<>();
         v.add(new ByteArrayInputStream("<root><a>".getBytes(charset)));
         v.add(blob.getInputStream());
         v.add(new ByteArrayInputStream("</a><b/></root>".getBytes(charset)));

--- a/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/sourcedelement/util/PullOMDataSource.java
+++ b/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/sourcedelement/util/PullOMDataSource.java
@@ -29,7 +29,7 @@ import org.apache.axiom.om.util.StAXUtils;
 public final class PullOMDataSource extends AbstractPullOMDataSource {
     private final String data;
     private final boolean destructive;
-    private final Set<CloseTestXMLStreamReaderWrapper> unclosedReaders = new HashSet<CloseTestXMLStreamReaderWrapper>();
+    private final Set<CloseTestXMLStreamReaderWrapper> unclosedReaders = new HashSet<>();
     private int readerRequestCount;
     private boolean destroyed;
 

--- a/testing/axiom-truth/src/main/java/org/apache/axiom/truth/AxiomTraverser.java
+++ b/testing/axiom-truth/src/main/java/org/apache/axiom/truth/AxiomTraverser.java
@@ -125,7 +125,7 @@ final class AxiomTraverser implements Traverser {
         for (Iterator<OMAttribute> it = ((OMElement) node).getAllAttributes(); it.hasNext(); ) {
             OMAttribute attr = it.next();
             if (attributes == null) {
-                attributes = new HashMap<QName, String>();
+                attributes = new HashMap<>();
             }
             attributes.put(attr.getQName(), attr.getAttributeValue());
         }
@@ -138,7 +138,7 @@ final class AxiomTraverser implements Traverser {
         for (Iterator<OMNamespace> it = ((OMElement) node).getAllDeclaredNamespaces(); it.hasNext(); ) {
             OMNamespace ns = it.next();
             if (namespaces == null) {
-                namespaces = new HashMap<String, String>();
+                namespaces = new HashMap<>();
             }
             namespaces.put(ns.getPrefix(), ns.getNamespaceURI());
         }

--- a/testing/dom-testsuite/src/main/java/org/apache/axiom/ts/dom/w3c/W3CDOMTestSuite.java
+++ b/testing/dom-testsuite/src/main/java/org/apache/axiom/ts/dom/w3c/W3CDOMTestSuite.java
@@ -40,7 +40,7 @@ public final class W3CDOMTestSuite {
             DOMTestSuiteFactory domTestSuiteFactory,
             DocumentBuilderFactoryFactory dbff,
             DOMFeature... unsupportedFeatures) {
-        Set<DOMFeature> unsupportedFeaturesSet = new HashSet<DOMFeature>(Arrays.asList(unsupportedFeatures));
+        Set<DOMFeature> unsupportedFeaturesSet = new HashSet<>(Arrays.asList(unsupportedFeatures));
 
         final DOMTestDocumentBuilderFactory factory;
         try {
@@ -70,7 +70,7 @@ public final class W3CDOMTestSuite {
             public void addTest(Class<? extends DOMTestCase> testClass) {
                 try {
                     if (!unsupportedFeaturesSet.isEmpty()) {
-                        Set<DOMFeature> usedFeatures = new HashSet<DOMFeature>();
+                        Set<DOMFeature> usedFeatures = new HashSet<>();
                         DOMFeature.matchFeatures(testClass, usedFeatures);
                         ClassReader classReader =
                                 new ClassReader(testClass.getResourceAsStream(testClass.getSimpleName() + ".class"));

--- a/testing/jaxp-testsuite/src/main/java/org/apache/axiom/ts/jaxp/stax/ParentLastURLClassLoader.java
+++ b/testing/jaxp-testsuite/src/main/java/org/apache/axiom/ts/jaxp/stax/ParentLastURLClassLoader.java
@@ -43,7 +43,7 @@ public class ParentLastURLClassLoader extends URLClassLoader {
         // Make sure that we return our own resources first. Otherwise, if an API performs
         // JDK 1.3 service discovery using getResources instead of getResource, we would
         // have a problem.
-        Vector<URL> resources = new Vector<URL>();
+        Vector<URL> resources = new Vector<>();
         Enumeration<URL> e = findResources(name);
         while (e.hasMoreElements()) {
             resources.add(e.nextElement());

--- a/testing/spring-ws-testsuite/src/main/java/org/apache/axiom/ts/springws/scenario/broker/BrokerEndpoint.java
+++ b/testing/spring-ws-testsuite/src/main/java/org/apache/axiom/ts/springws/scenario/broker/BrokerEndpoint.java
@@ -40,7 +40,7 @@ import org.springframework.xml.transform.TransformerHelper;
 public class BrokerEndpoint {
     private final CustomerService customerService;
     private final TransformerHelper transformerHelper = new TransformerHelper();
-    private final Deque<String> orderQueue = new LinkedList<String>();
+    private final Deque<String> orderQueue = new LinkedList<>();
 
     public BrokerEndpoint(CustomerService customerService) {
         this.customerService = customerService;


### PR DESCRIPTION
## Summary
- Replace explicit generic type arguments with the diamond operator (`<>`) where the type can be inferred, across field initializers, local variable declarations, and return statements.
- Left one occurrence unchanged (`XOPEncodingFilterHandler`) where the type argument carries a custom `@Union` type-use annotation used by the project's `union-checker`, since diamond inference with annotated type arguments under custom checkers can be unreliable.

## Test plan
- [ ] CI build passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01TNfZfhd9LbanHv6YGd2zXY)_